### PR TITLE
wrap C string in std::string as workaround to fix tests

### DIFF
--- a/src/cellid.cc
+++ b/src/cellid.cc
@@ -75,7 +75,7 @@ Handle<Value> CellId::New(const Arguments& args) {
             S2LatLng ll = node::ObjectWrap::Unwrap<LatLng>(fromObj)->get();
             obj->this_ = S2CellId::FromLatLng(ll);
         } else if (args[0]->IsString()) {
-            char* strnum = *NanAsciiString(args[0]);
+            std::string strnum {*NanAsciiString(args[0])};
             obj->this_ = S2CellId(ParseLeadingUInt64Value(strnum, 0));
         } else {
             return NanThrowError("Invalid input");
@@ -101,7 +101,7 @@ NAN_METHOD(CellId::FromToken) {
     if (args.Length() != 1 || !args[0]->IsString()) {
         return NanThrowError("(str) required");
     }
-    char* strtoken = *NanAsciiString(args[0]);
+    std::string strtoken {*NanAsciiString(args[0])};
     CellId* obj = node::ObjectWrap::Unwrap<CellId>(args.This());
     obj->this_ = S2CellId::FromToken(strtoken);
     NanReturnValue(args.This());


### PR DESCRIPTION
This PR fixes the tests. Commit 295fe45 broke the tests with the change from NanCString to NanAsciiString. It appears that the C strings returned from these functions differ. I didn't dig too deep into the code but string lengths were wrong for some reason. Wrapping the C string into std::string is a workaround that fixes the issue. 
