### PR TITLE
Upgrading addons to latest node APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.10
+  - "6.1"
 before_install:
 - export platform=$(uname -s | sed "y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/")
 - node --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0
+
+* [Upgrade addons to latest node APIs](https://github.com/mapbox/node-s2/pull/87)
+
 ## 0.4.0
 
 * [Add `result_type` option to GetCover](https://github.com/mapbox/node-s2/pull/78)

--- a/geometry/util/math/exactfloat/exactfloat.cc
+++ b/geometry/util/math/exactfloat/exactfloat.cc
@@ -91,9 +91,9 @@ ExactFloat::ExactFloat(double v) {
   using std::signbit;
 #endif
   sign_ = signbit(v) ? -1 : 1;
-  if (std::isnan(v)) {
+  if (isnan(v)) {
     set_nan();
-  } else if (std::isinf(v)) {
+  } else if (isinf(v)) {
     set_inf(sign_);
   } else {
     // The following code is much simpler than messing about with bit masks,

--- a/geometry/util/math/mathlimits.h
+++ b/geometry/util/math/mathlimits.h
@@ -191,11 +191,11 @@ DECL_UNSIGNED_INT_LIMITS(unsigned long long int)
   static bool IsNegInf(const Type x) { return _fpclass(x) == _FPCLASS_NINF; }
 #else
 #define DECL_FP_LIMIT_FUNCS \
-  static bool IsFinite(const Type x) { return !std::isinf(x)  &&  !std::isnan(x); } \
-  static bool IsNaN(const Type x) { return std::isnan(x); } \
-  static bool IsInf(const Type x) { return std::isinf(x); } \
-  static bool IsPosInf(const Type x) { return std::isinf(x)  &&  x > 0; } \
-  static bool IsNegInf(const Type x) { return std::isinf(x)  &&  x < 0; }
+  static bool IsFinite(const Type x) { return !isinf(x)  &&  !isnan(x); } \
+  static bool IsNaN(const Type x) { return isnan(x); } \
+  static bool IsInf(const Type x) { return isinf(x); } \
+  static bool IsPosInf(const Type x) { return isinf(x)  &&  x > 0; } \
+  static bool IsNegInf(const Type x) { return isinf(x)  &&  x < 0; }
 #endif
 
 // We can't put floating-point constant values in the header here because

--- a/geometry/util/math/matrix3x3-inl.h
+++ b/geometry/util/math/matrix3x3-inl.h
@@ -539,7 +539,7 @@ class Matrix3x3 {
   bool IsNaN() const {
     for ( int i = 0; i < 3; ++i ) {
       for ( int j = 0; j < 3; ++j ) {
-        if ( std::isnan(m_[i][j]) ) {
+        if ( isnan(m_[i][j]) ) {
           return true;
         }
       }

--- a/geometry/util/math/vector2-inl.h
+++ b/geometry/util/math/vector2-inl.h
@@ -315,7 +315,7 @@ void Vector2<VType>::Clear() {
 
 template <typename VType>
 bool Vector2<VType>::IsNaN() const {
-  return std::isnan(c_[0]) || std::isnan(c_[1]);
+  return isnan(c_[0]) || isnan(c_[1]);
 }
 
 template <typename VType>

--- a/geometry/util/math/vector3-inl.h
+++ b/geometry/util/math/vector3-inl.h
@@ -372,7 +372,7 @@ void Vector3<VType>::Clear() {
 
 template <typename VType>
 bool Vector3<VType>::IsNaN() const {
-  return std::isnan(c_[0]) || std::isnan(c_[1]) || std::isnan(c_[2]);
+  return isnan(c_[0]) || isnan(c_[1]) || isnan(c_[2]);
 }
 
 template <typename VType>

--- a/geometry/util/math/vector4-inl.h
+++ b/geometry/util/math/vector4-inl.h
@@ -372,7 +372,7 @@ void Vector4<VType>::Clear() {
 
 template <typename VType>
 bool Vector4<VType>::IsNaN() const {
-  return std::isnan(c_[0]) || std::isnan(c_[1]) || std::isnan(c_[2]) || std::isnan(c_[3]);
+  return isnan(c_[0]) || isnan(c_[1]) || isnan(c_[2]) || isnan(c_[3]);
 }
 
 template <typename VType>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "jshint index.js && tap --tap test/*.js"
   },
   "dependencies": {
-    "nan": "1.3.0",
+    "nan": "^2.4.0",
     "node-pre-gyp": "^0.5.19"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s2",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "index.js",
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build",

--- a/src/angle.h
+++ b/src/angle.h
@@ -7,7 +7,7 @@
 
 class Angle : public node::ObjectWrap {
 public:
-    static v8::Persistent<v8::FunctionTemplate> constructor;
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Init(v8::Handle<v8::Object> target);
     inline S1Angle get() { return this_; }
     static v8::Handle<v8::Value> New(const S1Angle c);
@@ -15,7 +15,7 @@ public:
 protected:
     Angle();
 
-    static v8::Handle<v8::Value> New(const v8::Arguments& args);
+    static NAN_METHOD(New);
     static NAN_METHOD(Normalize);
 
     S1Angle this_;

--- a/src/cap.h
+++ b/src/cap.h
@@ -7,7 +7,7 @@
 
 class Cap : public node::ObjectWrap {
 public:
-    static v8::Persistent<v8::FunctionTemplate> constructor;
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Init(v8::Handle<v8::Object> target);
     inline S2Cap get() { return this_; }
     static v8::Handle<v8::Value> New(const S2Cap ll);
@@ -15,7 +15,7 @@ public:
 protected:
     Cap();
 
-    static v8::Handle<v8::Value> New(const v8::Arguments& args);
+    static NAN_METHOD(New);
     static NAN_METHOD(GetRectBound);
     static NAN_METHOD(Intersects);
     static NAN_METHOD(InteriorIntersects);

--- a/src/cell.h
+++ b/src/cell.h
@@ -8,7 +8,7 @@
 
 class Cell : public node::ObjectWrap {
 public:
-    static v8::Persistent<v8::FunctionTemplate> constructor;
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Init(v8::Handle<v8::Object> target);
     inline S2Cell get() { return this_; }
     static v8::Handle<v8::Value> New(const S2Cell c);
@@ -17,7 +17,7 @@ public:
 protected:
     Cell();
 
-    static v8::Handle<v8::Value> New(const v8::Arguments& args);
+    static NAN_METHOD(New);
     // static v8::Handle<v8::Value> ApproxArea(const v8::Arguments& args);
     static NAN_METHOD(ApproxArea);
     static NAN_METHOD(ExactArea);

--- a/src/cellid.h
+++ b/src/cellid.h
@@ -7,7 +7,7 @@
 
 class CellId : public node::ObjectWrap {
 public:
-    static v8::Persistent<v8::FunctionTemplate> constructor;
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Init(v8::Handle<v8::Object> target);
     inline S2CellId get() { return this_; }
     static v8::Handle<v8::Value> New(const S2CellId c);
@@ -15,8 +15,7 @@ public:
 protected:
     CellId();
 
-    static v8::Handle<v8::Value> New(const v8::Arguments& args);
-
+    static NAN_METHOD(New);
     static NAN_METHOD(Level);
     static NAN_METHOD(ToToken);
     static NAN_METHOD(ToPoint);

--- a/src/interval.h
+++ b/src/interval.h
@@ -7,7 +7,7 @@
 
 class Interval : public node::ObjectWrap {
 public:
-    static v8::Persistent<v8::FunctionTemplate> constructor;
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Init(v8::Handle<v8::Object> target);
     inline S1Interval get() { return this_; }
     static v8::Handle<v8::Value> New(const S1Interval c);
@@ -15,7 +15,7 @@ public:
 protected:
     Interval();
 
-    static v8::Handle<v8::Value> New(const v8::Arguments& args);
+    static NAN_METHOD(New);
     static NAN_METHOD(GetLength);
     static NAN_METHOD(GetCenter);
     static NAN_METHOD(GetComplementCenter);

--- a/src/latlng.cc
+++ b/src/latlng.cc
@@ -10,122 +10,123 @@
 
 using namespace v8;
 
-Persistent<FunctionTemplate> LatLng::constructor;
+Nan::Persistent<FunctionTemplate> LatLng::constructor;
 
 void LatLng::Init(Handle<Object> target) {
-    NanScope();
+    Local<FunctionTemplate> tpl =
+      Nan::New<FunctionTemplate>(LatLng::New);
+  	constructor.Reset(tpl);
+    Local<String> name = Nan::New("S2LatLng").ToLocalChecked();
 
-    constructor = Persistent<FunctionTemplate>::New(FunctionTemplate::New(LatLng::New));
-    Local<String> name = String::NewSymbol("S2LatLng");
-
-    constructor->InstanceTemplate()->SetInternalFieldCount(1);
-    constructor->SetClassName(name);
+    tpl->InstanceTemplate()->SetInternalFieldCount(1);
+    tpl->SetClassName(name);
 
     // Add all prototype methods, getters and setters here.
-    NODE_SET_PROTOTYPE_METHOD(constructor, "normalized", Normalized);
-    NODE_SET_PROTOTYPE_METHOD(constructor, "isValid", IsValid);
-    NODE_SET_PROTOTYPE_METHOD(constructor, "toPoint", ToPoint);
-    NODE_SET_PROTOTYPE_METHOD(constructor, "distance", Distance);
-    NODE_SET_PROTOTYPE_METHOD(constructor, "toString", ToString);
+    Nan::SetPrototypeMethod(tpl, "normalized", Normalized);
+    Nan::SetPrototypeMethod(tpl, "isValid", IsValid);
+    Nan::SetPrototypeMethod(tpl, "toPoint", ToPoint);
+    Nan::SetPrototypeMethod(tpl, "distance", Distance);
+    Nan::SetPrototypeMethod(tpl, "toString", ToString);
 
-    Local<ObjectTemplate> proto = constructor->PrototypeTemplate();
-    proto->SetAccessor(NanNew<String>("lat"), Lat);
-    proto->SetAccessor(NanNew<String>("lng"), Lng);
+    Local<ObjectTemplate> proto = tpl->PrototypeTemplate();
+    Nan::SetAccessor(proto, Nan::New("lat").ToLocalChecked(), Lat);
+    Nan::SetAccessor(proto, Nan::New("lng").ToLocalChecked(), Lng);
 
     // This has to be last, otherwise the properties won't show up on the
     // object in JavaScript.
-    target->Set(name, constructor->GetFunction());
+    Nan::Set(target, name, tpl->GetFunction());
 }
 
 LatLng::LatLng()
     : ObjectWrap(),
       this_() {}
 
-Handle<Value> LatLng::New(const Arguments& args) {
-    NanScope();
-
-    if (!args.IsConstructCall()) {
-        return NanThrowError("Use the new operator to create instances of this object.");
+NAN_METHOD(LatLng::New) {
+    if (!info.IsConstructCall()) {
+        Nan::ThrowError("Use the new operator to create instances of this object.");
+        return;
     }
 
-    if (args[0]->IsExternal()) {
-        Local<External> ext = Local<External>::Cast(args[0]);
+    if (info[0]->IsExternal()) {
+        Local<External> ext = Local<External>::Cast(info[0]);
         void* ptr = ext->Value();
         LatLng* ll = static_cast<LatLng*>(ptr);
-        ll->Wrap(args.This());
-        return args.This();
+        ll->Wrap(info.This());
+        info.GetReturnValue().Set(info.This());
+        return;
     }
 
     LatLng* obj = new LatLng();
-    obj->Wrap(args.This());
+    obj->Wrap(info.This());
 
-    if (args.Length() == 2) {
-        if (args[0]->IsNumber() &&
-            args[1]->IsNumber()) {
+    if (info.Length() == 2) {
+        if (info[0]->IsNumber() &&
+            info[1]->IsNumber()) {
             obj->this_ = S2LatLng::FromDegrees(
-                args[0]->ToNumber()->Value(),
-                args[1]->ToNumber()->Value());
+                info[0]->ToNumber()->Value(),
+                info[1]->ToNumber()->Value());
         }
-    } else if (args.Length() == 1) {
-        Handle<Object> fromObj = args[0]->ToObject();
-        if (NanHasInstance(Point::constructor, fromObj)) {
+    } else if (info.Length() == 1) {
+        Handle<Object> fromObj = info[0]->ToObject();
+        Local<FunctionTemplate> constructorHandle =
+          Nan::New(Point::constructor);
+        if (constructorHandle->HasInstance(fromObj)) {
             S2Point p = node::ObjectWrap::Unwrap<Point>(fromObj)->get();
             obj->this_ = S2LatLng(p);
         } else {
-            return NanThrowError("Use the new operator to create instances of this object.");
+            Nan::ThrowError("Use the new operator to create instances of this object.");
+            return;
         }
     }
 
-    return args.This();
+    info.GetReturnValue().Set(info.This());
 }
 
 Handle<Value> LatLng::New(S2LatLng s2latlng) {
-    NanScope();
+    Nan::EscapableHandleScope scope;
     LatLng* obj = new LatLng();
     obj->this_ = s2latlng;
-    Handle<Value> ext = External::New(obj);
-    Handle<Object> handleObject = constructor->GetFunction()->NewInstance(1, &ext);
-    return scope.Close(handleObject);
+    Handle<Value> ext = Nan::New<External>(obj);
+    Local<FunctionTemplate> constructorHandle = Nan::New(constructor);
+    Handle<Object> handleObject =
+      constructorHandle->GetFunction()->NewInstance(1, &ext);
+    return scope.Escape(handleObject);
 }
 
 NAN_GETTER(LatLng::Lat) {
-    NanScope();
-    LatLng* obj = ObjectWrap::Unwrap<LatLng>(args.This());
-    NanReturnValue(NanNew<Number>(obj->this_.lat().degrees()));
+    LatLng* obj = ObjectWrap::Unwrap<LatLng>(info.This());
+    info.GetReturnValue().Set(Nan::New<Number>(obj->this_.lat().degrees()));
 }
 
 NAN_GETTER(LatLng::Lng) {
-    NanScope();
-    LatLng* obj = ObjectWrap::Unwrap<LatLng>(args.This());
-    NanReturnValue(NanNew<Number>(obj->this_.lng().degrees()));
+    LatLng* obj = ObjectWrap::Unwrap<LatLng>(info.This());
+    info.GetReturnValue().Set(Nan::New<Number>(obj->this_.lng().degrees()));
 }
 
 NAN_METHOD(LatLng::IsValid) {
-    NanScope();
-    LatLng* obj = ObjectWrap::Unwrap<LatLng>(args.This());
-    NanReturnValue(NanNew<Boolean>(obj->this_.is_valid()));
+    LatLng* obj = ObjectWrap::Unwrap<LatLng>(info.This());
+    info.GetReturnValue().Set(Nan::New<Boolean>(obj->this_.is_valid()));
 }
 
 NAN_METHOD(LatLng::Normalized) {
-    NanScope();
-    LatLng* obj = ObjectWrap::Unwrap<LatLng>(args.This());
-    return scope.Close(LatLng::New(obj->this_.Normalized()));
+    Nan::EscapableHandleScope scope;
+    LatLng* obj = ObjectWrap::Unwrap<LatLng>(info.This());
+    info.GetReturnValue().Set(scope.Escape(LatLng::New(obj->this_.Normalized())));
 }
 
 NAN_METHOD(LatLng::ToPoint) {
-    NanScope();
-    LatLng* obj = ObjectWrap::Unwrap<LatLng>(args.This());
-    return scope.Close(Point::New(obj->this_.ToPoint()));
+    Nan::EscapableHandleScope scope;
+    LatLng* obj = ObjectWrap::Unwrap<LatLng>(info.This());
+    info.GetReturnValue().Set(scope.Escape(Point::New(obj->this_.ToPoint())));
 }
 
 NAN_METHOD(LatLng::Distance) {
-    NanScope();
-    LatLng* latlng = node::ObjectWrap::Unwrap<LatLng>(args.This());
-    S2LatLng other = node::ObjectWrap::Unwrap<LatLng>(args[0]->ToObject())->get();
-    NanReturnValue(NanNew<Number>(latlng->this_.GetDistance(other).degrees()));
+    LatLng* latlng = node::ObjectWrap::Unwrap<LatLng>(info.This());
+    S2LatLng other = node::ObjectWrap::Unwrap<LatLng>(info[0]->ToObject())->get();
+    info.GetReturnValue().Set(Nan::New<Number>(latlng->this_.GetDistance(other).degrees()));
 }
+
 NAN_METHOD(LatLng::ToString) {
-    NanScope();
-    LatLng* latlng = node::ObjectWrap::Unwrap<LatLng>(args.This());
-    NanReturnValue(NanNew<String>(latlng->this_.ToStringInDegrees().c_str()));
+    LatLng* latlng = node::ObjectWrap::Unwrap<LatLng>(info.This());
+    info.GetReturnValue().Set(Nan::New(latlng->this_.ToStringInDegrees().c_str()).ToLocalChecked());
 }

--- a/src/latlng.h
+++ b/src/latlng.h
@@ -7,7 +7,7 @@
 
 class LatLng : public node::ObjectWrap {
 public:
-    static v8::Persistent<v8::FunctionTemplate> constructor;
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Init(v8::Handle<v8::Object> target);
     inline S2LatLng get() { return this_; }
     static v8::Handle<v8::Value> New(const S2LatLng ll);
@@ -15,7 +15,7 @@ public:
 protected:
     LatLng();
 
-    static v8::Handle<v8::Value> New(const v8::Arguments& args);
+    static NAN_METHOD(New);
     static NAN_GETTER(Lat);
     static NAN_GETTER(Lng);
     static NAN_METHOD(IsValid);

--- a/src/latlngrect.h
+++ b/src/latlngrect.h
@@ -7,7 +7,7 @@
 
 class LatLngRect : public node::ObjectWrap {
 public:
-    static v8::Persistent<v8::FunctionTemplate> constructor;
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Init(v8::Handle<v8::Object> target);
     inline S2LatLngRect get() { return this_; }
     static v8::Handle<v8::Value> New(const S2LatLngRect ll);
@@ -15,7 +15,7 @@ public:
 protected:
     LatLngRect();
 
-    static v8::Handle<v8::Value> New(const v8::Arguments& args);
+    static NAN_METHOD(New);
     static NAN_METHOD(GetCenter);
     static NAN_METHOD(GetSize);
     static NAN_METHOD(GetArea);

--- a/src/point.cc
+++ b/src/point.cc
@@ -8,82 +8,81 @@
 
 using namespace v8;
 
-Persistent<FunctionTemplate> Point::constructor;
+Nan::Persistent<FunctionTemplate> Point::constructor;
 
 void Point::Init(Handle<Object> target) {
-    NanScope();
+    Local<FunctionTemplate> tpl =
+      Nan::New<FunctionTemplate>(Point::New);
+    constructor.Reset(tpl);
+    Local<String> name = Nan::New("S2Point").ToLocalChecked();
 
-    constructor = Persistent<FunctionTemplate>::New(FunctionTemplate::New(Point::New));
-    Local<String> name = String::NewSymbol("S2Point");
+    tpl->InstanceTemplate()->SetInternalFieldCount(1);
+    tpl->SetClassName(name);
 
-    constructor->InstanceTemplate()->SetInternalFieldCount(1);
-    constructor->SetClassName(name);
+    Nan::SetPrototypeMethod(tpl, "x", X);
+    Nan::SetPrototypeMethod(tpl, "y", Y);
+    Nan::SetPrototypeMethod(tpl, "z", Z);
 
-    NODE_SET_PROTOTYPE_METHOD(constructor, "x", X);
-    NODE_SET_PROTOTYPE_METHOD(constructor, "y", Y);
-    NODE_SET_PROTOTYPE_METHOD(constructor, "z", Z);
-
-    target->Set(name, constructor->GetFunction());
+    Nan::Set(target, name, tpl->GetFunction());
 }
 
 Point::Point()
     : ObjectWrap(),
       this_() {}
 
-Handle<Value> Point::New(const Arguments& args) {
-    NanScope();
-
-    if (!args.IsConstructCall()) {
-        return NanThrowError("Use the new operator to create instances of this object.");
+NAN_METHOD(Point::New) {
+    if (!info.IsConstructCall()) {
+        Nan::ThrowError("Use the new operator to create instances of this object.");
+        return;
     }
 
-    if (args[0]->IsExternal()) {
-        Local<External> ext = Local<External>::Cast(args[0]);
+    if (info[0]->IsExternal()) {
+        Local<External> ext = Local<External>::Cast(info[0]);
         void* ptr = ext->Value();
         Point* p = static_cast<Point*>(ptr);
-        p->Wrap(args.This());
-        return args.This();
+        p->Wrap(info.This());
+        info.GetReturnValue().Set(info.This());
+        return;
     }
 
-    if (args.Length() != 3) {
-        return NanThrowError("(number, number, number) required");
+    if (info.Length() != 3) {
+        Nan::ThrowError("(number, number, number) required");
+        return;
     }
 
     Point* obj = new Point();
-
-    obj->Wrap(args.This());
+    obj->Wrap(info.This());
 
     obj->this_ = S2Point(
-        args[0]->ToNumber()->Value(),
-        args[1]->ToNumber()->Value(),
-        args[2]->ToNumber()->Value());
+        info[0]->ToNumber()->Value(),
+        info[1]->ToNumber()->Value(),
+        info[2]->ToNumber()->Value());
 
-    return args.This();
+    info.GetReturnValue().Set(info.This());
 }
 
 Handle<Value> Point::New(S2Point s2cell) {
-    NanScope();
+    Nan::EscapableHandleScope scope;
     Point* obj = new Point();
     obj->this_ = s2cell;
-    Handle<Value> ext = External::New(obj);
-    Handle<Object> handleObject = constructor->GetFunction()->NewInstance(1, &ext);
-    return scope.Close(handleObject);
+    Handle<Value> ext = Nan::New<External>(obj);
+    Local<FunctionTemplate> constructorHandle = Nan::New(constructor);
+    Handle<Object> handleObject =
+      constructorHandle->GetFunction()->NewInstance(1, &ext);
+    return scope.Escape(handleObject);
 }
 
 NAN_METHOD(Point::X) {
-    NanScope();
-    Point* obj = ObjectWrap::Unwrap<Point>(args.This());
-    NanReturnValue(NanNew<Number>(obj->this_.x()));
+    Point* obj = ObjectWrap::Unwrap<Point>(info.This());
+    info.GetReturnValue().Set(Nan::New<Number>(obj->this_.x()));
 }
 
 NAN_METHOD(Point::Y) {
-    NanScope();
-    Point* obj = ObjectWrap::Unwrap<Point>(args.This());
-    NanReturnValue(NanNew<Number>(obj->this_.y()));
+    Point* obj = ObjectWrap::Unwrap<Point>(info.This());
+    info.GetReturnValue().Set(Nan::New<Number>(obj->this_.y()));
 }
 
 NAN_METHOD(Point::Z) {
-    NanScope();
-    Point* obj = ObjectWrap::Unwrap<Point>(args.This());
-    NanReturnValue(NanNew<Number>(obj->this_.z()));
+    Point* obj = ObjectWrap::Unwrap<Point>(info.This());
+    info.GetReturnValue().Set(Nan::New<Number>(obj->this_.z()));
 }

--- a/src/point.h
+++ b/src/point.h
@@ -7,7 +7,7 @@
 
 class Point : public node::ObjectWrap {
 public:
-    static v8::Persistent<v8::FunctionTemplate> constructor;
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Init(v8::Handle<v8::Object> target);
     inline S2Point get() { return this_; }
     static v8::Handle<v8::Value> New(const S2Point c);
@@ -15,7 +15,7 @@ public:
 protected:
     Point();
 
-    static v8::Handle<v8::Value> New(const v8::Arguments& args);
+    static NAN_METHOD(New);
     static NAN_METHOD(X);
     static NAN_METHOD(Y);
     static NAN_METHOD(Z);

--- a/src/polygon.cc
+++ b/src/polygon.cc
@@ -17,52 +17,52 @@
 
 using namespace v8;
 
-Persistent<FunctionTemplate> Polygon::constructor;
+Nan::Persistent<FunctionTemplate> Polygon::constructor;
 
 void Polygon::Init(Handle<Object> target) {
-    NanScope();
+    Local<FunctionTemplate> tpl =
+      Nan::New<FunctionTemplate>(Polygon::New);
+    constructor.Reset(tpl);
+    Local<String> name = Nan::New("S2Polygon").ToLocalChecked();
 
-    constructor = Persistent<FunctionTemplate>::New(FunctionTemplate::New(Polygon::New));
-    Local<String> name = String::NewSymbol("S2Polygon");
+    tpl->InstanceTemplate()->SetInternalFieldCount(1);
+    tpl->SetClassName(name);
 
-    constructor->InstanceTemplate()->SetInternalFieldCount(1);
-    constructor->SetClassName(name);
+    // Nan::SetPrototypeMethod(tpl, "approxArea", ApproxArea);
 
-    // NODE_SET_PROTOTYPE_METHOD(constructor, "approxArea", ApproxArea);
-
-    target->Set(name, constructor->GetFunction());
+    Nan::Set(target, name, tpl->GetFunction());
 }
 
 Polygon::Polygon()
     : ObjectWrap() {}
 
-Handle<Value> Polygon::New(const Arguments& args) {
-    NanScope();
-
-    if (!args.IsConstructCall()) {
-        return NanThrowError("Use the new operator to create instances of this object.");
+NAN_METHOD(Polygon::New) {
+    if (!info.IsConstructCall()) {
+        Nan::ThrowError("Use the new operator to create instances of this object.");
+        return;
     }
 
-    if (args[0]->IsExternal()) {
-        Local<External> ext = Local<External>::Cast(args[0]);
+    if (info[0]->IsExternal()) {
+        Local<External> ext = Local<External>::Cast(info[0]);
         void* ptr = ext->Value();
         Polygon* ll = static_cast<Polygon*>(ptr);
-        ll->Wrap(args.This());
-        return args.This();
+        ll->Wrap(info.This());
+        info.GetReturnValue().Set(info.This());
+        return;
     }
 
-    if (args.Length() != 1) {
-        return NanThrowError("(latlng) required");
+    if (info.Length() != 1) {
+        Nan::ThrowError("(latlng) required");
+        return;
     }
 
     Polygon* obj = new Polygon();
-    obj->Wrap(args.This());
+    obj->Wrap(info.This());
 
-    return args.This();
+    info.GetReturnValue().Set(info.This());
 }
 
 // NAN_METHOD(Polygon::ApproxArea) {
-//     NanScope();
-//     Polygon* obj = ObjectWrap::Unwrap<Polygon>(args.This());
-//     NanReturnValue(NanNew<Number>(obj->this_.ApproxArea()));
+//     Polygon* obj = ObjectWrap::Unwrap<Polygon>(info.This());
+//     info.GetReturnValue().Set(Nan::New<Number>(obj->this_.ApproxArea()));
 // }

--- a/src/polygon.h
+++ b/src/polygon.h
@@ -7,13 +7,13 @@
 
 class Polygon : public node::ObjectWrap {
 public:
-    static v8::Persistent<v8::FunctionTemplate> constructor;
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Init(v8::Handle<v8::Object> target);
 
 protected:
     Polygon();
 
-    static v8::Handle<v8::Value> New(const v8::Arguments& args);
+    static NAN_METHOD(New);
     // static v8::Handle<v8::Value> ApproxArea(const v8::Arguments& args);
     // static NAN_METHOD(ApproxArea);
 };

--- a/src/polyline.h
+++ b/src/polyline.h
@@ -7,7 +7,7 @@
 
 class Polyline : public node::ObjectWrap {
 public:
-    static v8::Persistent<v8::FunctionTemplate> constructor;
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Init(v8::Handle<v8::Object> target);
     inline S2Polyline get() { return this_; }
     static v8::Handle<v8::Value> New(const S2Polyline c);
@@ -15,7 +15,7 @@ public:
 protected:
     Polyline();
 
-    static v8::Handle<v8::Value> New(const v8::Arguments& args);
+    static NAN_METHOD(New);
     static NAN_METHOD(GetCapBound);
     static NAN_METHOD(GetLength);
     static NAN_METHOD(GetCentroid);

--- a/src/regioncoverer.h
+++ b/src/regioncoverer.h
@@ -7,7 +7,7 @@
 
 class RegionCoverer : public node::ObjectWrap {
 public:
-    static v8::Persistent<v8::FunctionTemplate> constructor;
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Init(v8::Handle<v8::Object> target);
     // inline S2RegionCoverer get() { return this_; }
     static v8::Handle<v8::Value> New(const S2RegionCoverer c);
@@ -15,7 +15,7 @@ public:
 protected:
     RegionCoverer();
 
-    static v8::Handle<v8::Value> New(const v8::Arguments& args);
+    static NAN_METHOD(New);
     // static v8::Handle<v8::Value> ApproxArea(const v8::Arguments& args);
     // static NAN_METHOD(GetCenter);
 

--- a/src/s2.cc
+++ b/src/s2.cc
@@ -47,14 +47,14 @@ struct CoverConfiguration {
   S2Cap cap;
 };
 
-class CoverWorker : public NanAsyncWorker {
+class CoverWorker : public Nan::AsyncWorker {
  private:
   std::vector<S2CellId> cellids_vector;
 
  public:
-  CoverWorker(NanCallback *callback,
+  CoverWorker(Nan::Callback *callback,
               std::shared_ptr<CoverConfiguration> coverConfiguration)
-      : NanAsyncWorker(callback), coverConfiguration(coverConfiguration) {}
+      : Nan::AsyncWorker(callback), coverConfiguration(coverConfiguration) {}
   ~CoverWorker() {}
 
   // Executed inside the worker-thread.
@@ -96,9 +96,7 @@ class CoverWorker : public NanAsyncWorker {
   // this function will be run inside the main event loop
   // so it is safe to use V8 again
   void HandleOKCallback() {
-    NanScope();
-
-    Local<Array> out = Array::New(cellids_vector.size());
+    Local<Array> out = Nan::New<Array>(cellids_vector.size());
     if (coverConfiguration->result_type == "cell") {
       for (std::size_t i = 0; i < cellids_vector.size(); ++i) {
         out->Set(i, Cell::New(cellids_vector.at(i)));
@@ -109,11 +107,11 @@ class CoverWorker : public NanAsyncWorker {
       }
     } else if (coverConfiguration->result_type == "string") {
       for (std::size_t i = 0; i < cellids_vector.size(); ++i) {
-        out->Set(i, NanNew<String>(cellids_vector.at(i).ToString()));
+        out->Set(i, Nan::New(cellids_vector.at(i).ToString()).ToLocalChecked());
       }
     } else if (coverConfiguration->result_type == "token") {
       for (std::size_t i = 0; i < cellids_vector.size(); ++i) {
-        out->Set(i, NanNew<String>(cellids_vector.at(i).ToToken()));
+        out->Set(i, Nan::New(cellids_vector.at(i).ToToken()).ToLocalChecked());
       }
     } else if (coverConfiguration->result_type == "point") {
             for (std::size_t i = 0; i < cellids_vector.size(); ++i) {
@@ -121,17 +119,20 @@ class CoverWorker : public NanAsyncWorker {
       }
     }
     if (coverConfiguration->type == "undefined") {
-      v8::Local<v8::Value> argv[] = {Exception::Error(String::New("cover type not specified")), NanNull()};
+      v8::Local<v8::Value> argv[] ={
+        Exception::Error(Nan::New("cover type not specified").ToLocalChecked()),
+        Nan::Null()
+      };
       callback->Call(2, argv);
     } else {
-      v8::Local<v8::Value> argv[] = {NanNull(), out};
+      v8::Local<v8::Value> argv[] = {Nan::Null(), out};
       callback->Call(2, argv);
     }
   }
 
   void HandleErrorCallback() {
-    NanScope();
-    Local<Value> argv[] = {Exception::Error(String::New("fail!"))};
+    Local<Value> argv[] =
+      {Exception::Error(Nan::New("fail!").ToLocalChecked())};
     callback->Call(1, argv);
   };
 
@@ -140,50 +141,56 @@ class CoverWorker : public NanAsyncWorker {
 };
 
 NAN_METHOD(GetCover) {
-  NanScope();
-
-  if (args.Length() < 1) {
-    return NanThrowError("(array, [min, max, mod]) required");
+  if (info.Length() < 1) {
+    Nan::ThrowError("(array, [min, max, mod]) required");
+    return;
   }
 
   typedef std::vector<pair<S2Point, S2Point>> EdgeList;
   std::shared_ptr<CoverConfiguration> coverConfiguration =
       std::make_shared<CoverConfiguration>();
 
-  if (args.Length() > 2) {
-    Handle<Object> opt = args[1]->ToObject();
-    if (opt->Has(NanNew<String>("min"))) {
+  if (info.Length() > 2) {
+    Handle<Object> opt = info[1]->ToObject();
+    if (opt->Has(Nan::New("min").ToLocalChecked())) {
       coverConfiguration->min_level =
-          opt->Get(NanNew<String>("min"))->ToInteger()->Value();
+          opt->Get(Nan::New("min").ToLocalChecked())->ToInteger()->Value();
     }
-    if (opt->Has(NanNew<String>("max"))) {
+    if (opt->Has(Nan::New("max").ToLocalChecked())) {
       coverConfiguration->max_level =
-          opt->Get(NanNew<String>("max"))->ToInteger()->Value();
+          opt->Get(Nan::New("max").ToLocalChecked())->ToInteger()->Value();
     }
-    if (opt->Has(NanNew<String>("mod"))) {
+    if (opt->Has(Nan::New("mod").ToLocalChecked())) {
       coverConfiguration->level_mod =
-          opt->Get(NanNew<String>("mod"))->ToInteger()->Value();
+          opt->Get(Nan::New("mod").ToLocalChecked())->ToInteger()->Value();
     }
-    if (opt->Has(NanNew<String>("max_cells"))) {
+    if (opt->Has(Nan::New("max_cells").ToLocalChecked())) {
       coverConfiguration->max_cells =
-          opt->Get(NanNew<String>("max_cells"))->ToInteger()->Value();
+          opt->Get(Nan::New("max_cells").ToLocalChecked())->ToInteger()->Value();
     }
-    if (opt->Has(NanNew<String>("type"))) {
+    if (opt->Has(Nan::New("type").ToLocalChecked())) {
       coverConfiguration->type =
-          *NanAsciiString(opt->Get(NanNew<String>("type")));
+          *Nan::Utf8String(opt->Get(Nan::New("type").ToLocalChecked()));
     }
-    if (opt->Has(NanNew<String>("result_type"))) {
+    if (opt->Has(Nan::New("result_type").ToLocalChecked())) {
       coverConfiguration->result_type =
-          *NanAsciiString(opt->Get(NanNew<String>("result_type")));
+          *Nan::Utf8String(opt->Get(Nan::New("result_type").ToLocalChecked()));
     }
   }
 
   // Check the number of arguments. we need size-1 as the callback always goes
   // last
-  NanCallback *callback =
-      new NanCallback(args[args.Length() - 1].As<Function>());
-  if (args[0]->IsArray()) {
-    Handle<Array> array = Handle<Array>::Cast(args[0]);
+  Nan::Callback *callback =
+      new Nan::Callback(info[info.Length() - 1].As<Function>());
+
+  Local<FunctionTemplate> constructorHandleLlr =
+    Nan::New(LatLngRect::constructor);
+  Local<FunctionTemplate> constructorHandleCell =
+    Nan::New(Cell::constructor);
+  Local<FunctionTemplate> constructorHandleCap =
+    Nan::New(Cap::constructor);
+  if (info[0]->IsArray()) {
+    Handle<Array> array = Handle<Array>::Cast(info[0]);
 
     if (coverConfiguration->type == "polygon") {
       S2PolygonBuilderOptions polyOptions;
@@ -199,11 +206,14 @@ NAN_METHOD(GetCover) {
 
         for (std::size_t ii = 0; ii < pointArray->Length(); ++ii) {
           Local<Object> obj = pointArray->Get(ii)->ToObject();
-          if (NanHasInstance(Point::constructor, obj)) {
+          Local<FunctionTemplate> constructorHandle =
+            Nan::New(Point::constructor);
+          if (constructorHandle->HasInstance(obj)) {
             S2Point p = node::ObjectWrap::Unwrap<Point>(obj)->get();
             points.push_back(p);
           } else {
-            return NanThrowError("array must contain only points");
+            Nan::ThrowError("array must contain only points");
+            return;
           }
         }
         // construct polygon loop
@@ -219,7 +229,8 @@ NAN_METHOD(GetCover) {
           loop.Invert();
         }
         if (!loop.IsValid()) {
-          return NanThrowError("invalid loop");
+          Nan::ThrowError("invalid loop");
+          return;
         }
         builder.AddLoop(&loop);
       }
@@ -230,12 +241,15 @@ NAN_METHOD(GetCover) {
       std::vector<S2Point> points;
       for (std::size_t i = 0; i < array->Length(); ++i) {
         Local<Object> obj = array->Get(i)->ToObject();
-        if (NanHasInstance(Point::constructor, obj)) {
+        Local<FunctionTemplate> constructorHandle =
+          Nan::New(Point::constructor);
+        if (constructorHandle->HasInstance(obj)) {
           S2Point p =
               node::ObjectWrap::Unwrap<Point>(array->Get(i)->ToObject())->get();
           points.push_back(p);
         } else {
-          return NanThrowError("array must contain only points");
+          Nan::ThrowError("array must contain only points");
+          return;
         }
       }
       coverConfiguration->polyline = std::make_shared<S2Polyline>(points);
@@ -254,11 +268,14 @@ NAN_METHOD(GetCover) {
           Handle<Array> pointArray = Handle<Array>::Cast(ringArray->Get(i));
           for (std::size_t ii = 0; ii < pointArray->Length(); ++ii) {
             Local<Object> obj = pointArray->Get(ii)->ToObject();
-            if (NanHasInstance(Point::constructor, obj)) {
+            Local<FunctionTemplate> constructorHandle =
+              Nan::New(Point::constructor);
+            if (constructorHandle->HasInstance(obj)) {
               S2Point p = node::ObjectWrap::Unwrap<Point>(obj)->get();
               points.push_back(p);
             } else {
-              return NanThrowError("array must contain only points");
+              Nan::ThrowError("array must contain only points");
+              return;
             }
           }
           // construct polygon loop
@@ -274,7 +291,8 @@ NAN_METHOD(GetCover) {
             loop.Invert();
           }
           if (!loop.IsValid()) {
-            return NanThrowError("invalid loop");
+            Nan::ThrowError("invalid loop");
+            return;
           }
           builder.AddLoop(&loop);
         }
@@ -283,31 +301,30 @@ NAN_METHOD(GetCover) {
       EdgeList edgeList;
       builder.AssemblePolygon(&coverConfiguration->polygon, &edgeList);
     }
-  } else if (NanHasInstance(LatLngRect::constructor, args[0])) {
+  } else if (constructorHandleLlr->HasInstance(info[0])) {
     coverConfiguration->type = "rect";
     coverConfiguration->rect =
-        node::ObjectWrap::Unwrap<LatLngRect>(args[0]->ToObject())->get();
-  } else if (NanHasInstance(Cell::constructor, args[0])) {
+        node::ObjectWrap::Unwrap<LatLngRect>(info[0]->ToObject())->get();
+  } else if (constructorHandleCell->HasInstance(info[0])) {
     coverConfiguration->type = "cell";
     coverConfiguration->cell =
-        node::ObjectWrap::Unwrap<Cell>(args[0]->ToObject())->get();
-  } else if (NanHasInstance(Cap::constructor, args[0])) {
+        node::ObjectWrap::Unwrap<Cell>(info[0]->ToObject())->get();
+  } else if (constructorHandleCap->HasInstance(info[0])) {
     coverConfiguration->type = "cap";
     coverConfiguration->cap =
-        node::ObjectWrap::Unwrap<Cap>(args[0]->ToObject())->get();
+        node::ObjectWrap::Unwrap<Cap>(info[0]->ToObject())->get();
   } else {
     coverConfiguration->type = "undefined";
   }
 
-  NanAsyncQueueWorker(new CoverWorker(callback, coverConfiguration));
-  NanReturnUndefined();
+  Nan::AsyncQueueWorker(new CoverWorker(callback, coverConfiguration));
+  info.GetReturnValue().Set(Nan::Undefined());
 }
 
 NAN_METHOD(GetCoverSync) {
-  NanScope();
-
-  if (args.Length() < 1) {
-    return NanThrowError("(array, [min, max, mod]) required");
+  if (info.Length() < 1) {
+    Nan::ThrowError("(array, [min, max, mod]) required");
+    return;
   }
 
   typedef std::vector<pair<S2Point, S2Point>> EdgeList;
@@ -317,34 +334,40 @@ NAN_METHOD(GetCoverSync) {
   std::string type{"polygon"};
   std::string result_type{"cell"};
 
-  if (args.Length() > 1) {
-    Handle<Object> opt = args[1]->ToObject();
-    if (opt->Has(NanNew<String>("min"))) {
+  if (info.Length() > 1) {
+    Handle<Object> opt = info[1]->ToObject();
+    if (opt->Has(Nan::New("min").ToLocalChecked())) {
       coverer.set_min_level(
-          opt->Get(NanNew<String>("min"))->ToInteger()->Value());
+          opt->Get(Nan::New("min").ToLocalChecked())->ToInteger()->Value());
     }
-    if (opt->Has(NanNew<String>("max"))) {
+    if (opt->Has(Nan::New("max").ToLocalChecked())) {
       coverer.set_max_level(
-          opt->Get(NanNew<String>("max"))->ToInteger()->Value());
+          opt->Get(Nan::New("max").ToLocalChecked())->ToInteger()->Value());
     }
-    if (opt->Has(NanNew<String>("mod"))) {
+    if (opt->Has(Nan::New("mod").ToLocalChecked())) {
       coverer.set_level_mod(
-          opt->Get(NanNew<String>("mod"))->ToInteger()->Value());
+          opt->Get(Nan::New("mod").ToLocalChecked())->ToInteger()->Value());
     }
-    if (opt->Has(NanNew<String>("max_cells"))) {
+    if (opt->Has(Nan::New("max_cells").ToLocalChecked())) {
       coverer.set_max_cells(
-          opt->Get(NanNew<String>("max_cells"))->ToInteger()->Value());
+          opt->Get(Nan::New("max_cells").ToLocalChecked())->ToInteger()->Value());
     }
-    if (opt->Has(NanNew<String>("type"))) {
-      type = *NanAsciiString(opt->Get(NanNew<String>("type")));
+    if (opt->Has(Nan::New("type").ToLocalChecked())) {
+      type = *Nan::Utf8String(opt->Get(Nan::New("type").ToLocalChecked()));
     }
-    if (opt->Has(NanNew<String>("result_type"))) {
-      result_type = *NanAsciiString(opt->Get(NanNew<String>("result_type")));
+    if (opt->Has(Nan::New("result_type").ToLocalChecked())) {
+      result_type = *Nan::Utf8String(opt->Get(Nan::New("result_type").ToLocalChecked()));
     }
   }
 
-  if (args[0]->IsArray()) {
-    Handle<Array> array = Handle<Array>::Cast(args[0]);
+  Local<FunctionTemplate> constructorHandleLlr =
+    Nan::New(LatLngRect::constructor);
+  Local<FunctionTemplate> constructorHandleCell =
+    Nan::New(Cell::constructor);
+  Local<FunctionTemplate> constructorHandleCap =
+    Nan::New(Cap::constructor);
+  if (info[0]->IsArray()) {
+    Handle<Array> array = Handle<Array>::Cast(info[0]);
 
     if (type == "polygon") {
       S2PolygonBuilderOptions polyOptions;
@@ -361,11 +384,14 @@ NAN_METHOD(GetCoverSync) {
 
         for (std::size_t ii = 0; ii < pointArray->Length(); ++ii) {
           Local<Object> obj = pointArray->Get(ii)->ToObject();
-          if (NanHasInstance(Point::constructor, obj)) {
+          Local<FunctionTemplate> constructorHandle =
+            Nan::New(Point::constructor);
+          if (constructorHandle->HasInstance(obj)) {
             S2Point p = node::ObjectWrap::Unwrap<Point>(obj)->get();
             points.push_back(p);
           } else {
-            return NanThrowError("array must contain only points");
+            Nan::ThrowError("array must contain only points");
+            return;
           }
         }
         // construct polygon loop
@@ -382,7 +408,8 @@ NAN_METHOD(GetCoverSync) {
         }
 
         if (!loop.IsValid()) {
-          return NanThrowError("invalid loop");
+          Nan::ThrowError("invalid loop");
+          return;
         }
 
         builder.AddLoop(&loop);
@@ -395,12 +422,15 @@ NAN_METHOD(GetCoverSync) {
       std::vector<S2Point> points;
       for (std::size_t i = 0; i < array->Length(); ++i) {
         Local<Object> obj = array->Get(i)->ToObject();
-        if (NanHasInstance(Point::constructor, obj)) {
+        Local<FunctionTemplate> constructorHandle =
+          Nan::New(Point::constructor);
+        if (constructorHandle->HasInstance(obj)) {
           S2Point p =
               node::ObjectWrap::Unwrap<Point>(array->Get(i)->ToObject())->get();
           points.push_back(p);
         } else {
-          return NanThrowError("array must contain only points");
+          Nan::ThrowError("array must contain only points");
+          return;
         }
       }
       S2Polyline polyline(points);
@@ -414,6 +444,8 @@ NAN_METHOD(GetCoverSync) {
       S2Polygon polygon;
       std::vector<S2Point> rings;
 
+      Local<FunctionTemplate> constructorHandle =
+        Nan::New(Point::constructor);
       for (std::size_t k = 0; k < array->Length(); ++k) {
         Handle<Array> ringArray = Handle<Array>::Cast(array->Get(k));
         for (std::size_t i = 0; i < ringArray->Length(); ++i) {
@@ -421,11 +453,12 @@ NAN_METHOD(GetCoverSync) {
           Handle<Array> pointArray = Handle<Array>::Cast(ringArray->Get(i));
           for (std::size_t ii = 0; ii < pointArray->Length(); ++ii) {
             Local<Object> obj = pointArray->Get(ii)->ToObject();
-            if (NanHasInstance(Point::constructor, obj)) {
+            if (constructorHandle->HasInstance(obj)) {
               S2Point p = node::ObjectWrap::Unwrap<Point>(obj)->get();
               points.push_back(p);
             } else {
-              return NanThrowError("array must contain only points");
+              Nan::ThrowError("array must contain only points");
+              return;
             }
           }
           // construct polygon loop
@@ -442,7 +475,8 @@ NAN_METHOD(GetCoverSync) {
           }
 
           if (!loop.IsValid()) {
-            return NanThrowError("invalid loop");
+            Nan::ThrowError("invalid loop");
+            return;
           }
 
           builder.AddLoop(&loop);
@@ -453,21 +487,22 @@ NAN_METHOD(GetCoverSync) {
       builder.AssemblePolygon(&polygon, &edgeList);
       coverer.GetCovering(polygon, &cellids_vector);
     }
-  } else if (NanHasInstance(LatLngRect::constructor, args[0])) {
+  } else if (constructorHandleLlr->HasInstance(info[0])) {
     S2LatLngRect rect =
-        node::ObjectWrap::Unwrap<LatLngRect>(args[0]->ToObject())->get();
+        node::ObjectWrap::Unwrap<LatLngRect>(info[0]->ToObject())->get();
     coverer.GetCovering(rect, &cellids_vector);
-  } else if (NanHasInstance(Cell::constructor, args[0])) {
-    S2Cell cell = node::ObjectWrap::Unwrap<Cell>(args[0]->ToObject())->get();
+  } else if (constructorHandleCell->HasInstance(info[0])) {
+    S2Cell cell = node::ObjectWrap::Unwrap<Cell>(info[0]->ToObject())->get();
     coverer.GetCovering(cell, &cellids_vector);
-  } else if (NanHasInstance(Cap::constructor, args[0])) {
-    S2Cap cap = node::ObjectWrap::Unwrap<Cap>(args[0]->ToObject())->get();
+  } else if (constructorHandleCap->HasInstance(info[0])) {
+    S2Cap cap = node::ObjectWrap::Unwrap<Cap>(info[0]->ToObject())->get();
     coverer.GetCovering(cap, &cellids_vector);
   } else {
-    return NanThrowError("incompatible object to cover");
+    Nan::ThrowError("incompatible object to cover");
+    return;
   }
 
-  Local<Array> out = Array::New(cellids_vector.size());
+  Local<Array> out = Nan::New<Array>(cellids_vector.size());
   if (result_type == "cell") {
     for (std::size_t i = 0; i < cellids_vector.size(); ++i) {
       out->Set(i, Cell::New(cellids_vector.at(i)));
@@ -478,11 +513,11 @@ NAN_METHOD(GetCoverSync) {
     }
   } else if (result_type == "string") {
     for (std::size_t i = 0; i < cellids_vector.size(); ++i) {
-      out->Set(i, NanNew<String>(cellids_vector.at(i).ToString()));
+      out->Set(i, Nan::New(cellids_vector.at(i).ToString()).ToLocalChecked());
     }
   } else if (result_type == "token") {
     for (std::size_t i = 0; i < cellids_vector.size(); ++i) {
-      out->Set(i, NanNew<String>(cellids_vector.at(i).ToToken()));
+      out->Set(i, Nan::New(cellids_vector.at(i).ToToken()).ToLocalChecked());
     }
   } else if (result_type == "point") {
     for (std::size_t i = 0; i < cellids_vector.size(); ++i) {
@@ -490,7 +525,7 @@ NAN_METHOD(GetCoverSync) {
     }
   }
 
-  NanReturnValue(out);
+  info.GetReturnValue().Set(out);
 }
 
 void RegisterModule(Handle<Object> exports) {
@@ -503,10 +538,10 @@ void RegisterModule(Handle<Object> exports) {
   Point::Init(exports);
   Interval::Init(exports);
   Polyline::Init(exports);
-  exports->Set(NanNew<String>("getCoverSync"),
-               NanNew<FunctionTemplate>(GetCoverSync)->GetFunction());
-  exports->Set(NanNew<String>("getCover"),
-               NanNew<FunctionTemplate>(GetCover)->GetFunction());
+  exports->Set(Nan::New("getCoverSync").ToLocalChecked(),
+               Nan::New<FunctionTemplate>(GetCoverSync)->GetFunction());
+  exports->Set(Nan::New("getCover").ToLocalChecked(),
+               Nan::New<FunctionTemplate>(GetCover)->GetFunction());
 }
 
 NODE_MODULE(_s2, RegisterModule);


### PR DESCRIPTION
This PR updates the `C++` addon code to the latest node.js APIs. I used the latest version of `nan` and made heavier use of it throughout.

I only tested it on macOS (Sierra) so far, but in `geometry/util/math` I had to replace `std::isinf` and `std::isnan` with `isinf` and `isnan`, which is a little strange. I don't know yet if that works on other systems as well.

Two test cases fail currently, `getCoveringSync - llrect` and `getCovering - llrect`, where I get the result `40` instead of `34`.

Note: Now I see that on Travis all the tests ran successfully, so not sure what causes the two fails for me.
